### PR TITLE
SSL verification and plugin disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ submitting feature requests or issues to [issues][githubissues].
 
 ## Requires
 * pytest >= 2.2.3
-* jira >= 0.13
+* jira >= 0.43
 * six
 
 ## Installation
@@ -43,6 +43,7 @@ submitting feature requests or issues to [issues][githubissues].
   url = https://jira.atlassian.com
   username = USERNAME (or blank for no authentication)
   password = PASSWORD (or blank for no authentication)
+  # ssl_verification = True/False
   ```
 
   Options can be overridden with command line options.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest>=2.2.4
-jira>=0.13
+jira>=0.43
 six
 ordereddict; python_version=='2.6'


### PR DESCRIPTION
1) if connection to Jira wasn't established, plugin won't be loaded
2) it's possible to disable ssl verification to jira