### PR TITLE
Report invalid parameter of decorator

### DIFF
--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -67,9 +67,14 @@ class JiraHooks(object):
             )
 
         # Filter valid issues, and return unique issues
-        return [
-            jid for jid in set(jira_ids) if issue_pattern.match(jid)
-        ]
+        for jid in set(jira_ids):
+            if not issue_pattern.match(jid):
+                raise ValueError(
+                    'JIRA marker argument `%s` does not match pattern' % jid
+                )
+        return list(
+            set(jira_ids)
+        )
 
     def is_issue_resolved(self, issue_id):
         '''

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 
 
@@ -50,7 +49,6 @@ def test_jira_marker_no_args(testdir):
     assert_outcomes(result, 0, 0, 0, 1)
 
 
-@pytest.mark.xfail(reason="It doesn't fail but it should, need to fix (#25)")
 def test_jira_marker_bad_args(testdir):
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile("""


### PR DESCRIPTION
Exception is raised if the parametr of jira marker decorator
does not match the pattern.