### PR TITLE
Add OrderedDict to be installed for py2.6

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 flake8
 pytest-cov
+ordereddict; python_version < '2.7'


### PR DESCRIPTION
it is needed by flake8, but it already dropped py2.6 compatibility