### PR TITLE
Exclude flake8 execution for py26

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py26,py27,py34,py35,pep8
 [tox:travis]
-2.6 = py26, pep8
+2.6 = py26
 2.7 = py27, pep8
 3.4 = py34, pep8
 3.5 = py35, pep8


### PR DESCRIPTION
flake8 dropped support for py26