### PR TITLE
packaging: enforce flake8==3.3.0 for py2.6

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
-flake8
+flake8==3.3.0; python_version=='2.6'
+flake8; python_version>'2.6'
 coverage


### PR DESCRIPTION
flake8 future versions dropped support for py2.6