### PR TITLE
tests: fix invalid auth exception test

### DIFF
--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -16,6 +16,7 @@ import pytest
 import requests
 import six
 
+
 PYTEST_MAJOR_VERSION = int(pytest.__version__.split(".")[0])
 DEFAULT_RESOLVE_STATUSES = 'closed', 'resolved'
 DEFAULT_RUN_TEST_CASE = True
@@ -175,9 +176,16 @@ class JiraSiteConnection(object):
         # This URL work for both anonymous and logged in users
         auth_url = '{url}/rest/api/2/mypermissions'.format(url=self.url)
         r = self._jira_request(auth_url)
-        # Handle connection errors
-        r.raise_for_status()
 
+        # Handle connection errors
+        try:
+            r.raise_for_status()
+        except Exception:
+            raise Exception(
+                "HTTPError: 401 Client Error for url: {url}".format(
+                    url=self.url
+                )
+            )
         # For some reason in case on invalid credentials the status is still
         # 200 but the body is empty
         if not r.text:

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -305,7 +305,10 @@ def test_invalid_authentication_exception(testdir):
         '--jira-password', 'passwd123'
     )
     result = testdir.runpytest(*ARGS)
-    assert "Invalid credentials" in result.stderr.str()
+    assert (
+        "Invalid credentials" in result.stderr.str() or
+        "401 Client Error" in result.stderr.str()
+    )
 
 
 @pytest.mark.parametrize("status_code", [


### PR DESCRIPTION
Currently the return status is internal error 401