### PR TITLE
Added keyword option "skipif" to disable issue marker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,11 @@ Test results
    -  the test is executed and based on it
       the result is **passed** or **failed**
 
+- If the **skipif** parameter is provided ...
+
+  -  with value *False* or *callable returning False-like value* jira marker line is **ignored**
+
+
 **NOTE:** You can set default value for ``run`` parameter globally in config
 file (option ``run_test_case``) or from CLI
 ``--jira-do-not-run-test-case``. Default value is ``run=True``.
@@ -55,8 +60,9 @@ Strategies for dealing with issue IDs that were not found:
 
 Issue ID in decorator
 ~~~~~~~~~~~~~~~~~~~~~
-If you use decorator you can specify optional parameter ``run``. If it's false
-and issue is unresolved, the test will be skipped.
+If you use decorator you can specify optional parameters ``run`` and ``skipif``.
+If ``run`` is false and issue is unresolved, the test will be skipped.
+If ``skipif`` is is false jira marker line will be ignored.
 
 .. code:: python
 
@@ -67,6 +73,12 @@ and issue is unresolved, the test will be skipped.
   @pytest.mark.jira("ORG-1382")
   def test_xfail(): # will run and xfail if unresolved
       assert False
+
+  @pytest.mark.jira("ORG-1382", skipif=False)
+  def test_fail():  # will run and fail as jira marker is ignored
+      assert False
+
+
 
 Issue ID in docstring
 ~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,21 @@ If ``skipif`` is is false jira marker line will be ignored.
   def test_fail():  # will run and fail as jira marker is ignored
       assert False
 
+Using lambda value for skipif
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+You can use value for ``skipif`` parameter. Lambda function must take
+issue JSON as input value and return boolean-like value. If any JIRA ID
+returns False-like value marker line will be ignored.
+
+.. code:: python
+
+  @pytest.mark.jira("ORG-1382", skipif=lambda i: 'my component' in i['components'])
+  def test_fail():  # Test will run if 'my component' is not present in Jira issue's components
+      assert False
+
+  @pytest.mark.jira("ORG-1382", "ORG-1412", skipif=lambda i: 'to do' == i['status'])
+  def test_fail():  # Test will run if either of JIRA issue's status differs from 'to do'
+      assert False
 
 
 Issue ID in docstring

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Using lambda value for skipif
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can use lambda value for ``skipif`` parameter. Lambda function must take
 issue JSON as input value and return boolean-like value. If any JIRA ID
-returns False-like value marker line will be ignored.
+gets False-like value marker for that issue will be ignored.
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ If ``skipif`` is is false jira marker line will be ignored.
 
 Using lambda value for skipif
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You can use value for ``skipif`` parameter. Lambda function must take
+You can use lambda value for ``skipif`` parameter. Lambda function must take
 issue JSON as input value and return boolean-like value. If any JIRA ID
 returns False-like value marker line will be ignored.
 

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -240,9 +240,14 @@ class JiraMarkerReporter(object):
         # Was the jira marker used?
         if 'jira' in item.keywords:
             marker = item.keywords['jira']
-            if len(marker.args) == 0:
-                raise TypeError('JIRA marker requires one, or more, arguments')
-            jira_ids.extend(item.keywords['jira'].args)
+            # process markers independently
+            for mark in marker:
+                if not mark.kwargs.get('condition', True):
+                    continue
+
+                if len(mark.args) == 0:
+                    raise TypeError('JIRA marker requires one, or more, arguments')
+                jira_ids.extend(mark.args)
 
         # Was a jira issue referenced in the docstr?
         if self.docs and item.function.__doc__:

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -242,11 +242,16 @@ class JiraMarkerReporter(object):
             marker = item.keywords['jira']
             # process markers independently
             for mark in marker:
-                if not mark.kwargs.get('condition', True):
+                skip_if = mark.kwargs.get('skipif', True)
+                if callable(skip_if):
+                    if not skip_if():
+                        continue
+                elif not skip_if:
                     continue
 
                 if len(mark.args) == 0:
-                    raise TypeError('JIRA marker requires one, or more, arguments')
+                    raise TypeError(
+                        'JIRA marker requires one, or more, arguments')
                 jira_ids.extend(mark.args)
 
         # Was a jira issue referenced in the docstr?

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -138,7 +138,7 @@ def test_open_jira_marker_pass(testdir):
 
 
 def test_open_jira_marker_with_condition_pass(testdir):
-    """Expected skip due to unresolved JIRA"""
+    """Expected skip due to unresolved JIRA when condition is True"""
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile("""
         import pytest
@@ -152,7 +152,7 @@ def test_open_jira_marker_with_condition_pass(testdir):
 
 
 def test_open_jira_marker_without_condition_fail(testdir):
-    """Expected skip due to unresolved JIRA"""
+    """Expected test to fail as unresolved JIRA has been marked with False condition"""
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile("""
         import pytest
@@ -166,7 +166,7 @@ def test_open_jira_marker_without_condition_fail(testdir):
 
 
 def test_multiple_jira_markers_with_condition_pass(testdir):
-    """Expected skip due to unresolved JIRA"""
+    """Expected test to skip due to multiple JIRA lines with condition set"""
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile("""
         import pytest
@@ -195,7 +195,7 @@ def test_multiple_jira_markers_open_without_condition_fail(testdir):
     result.assert_outcomes(0, 0, 1)
 
 def test_multiple_jira_markers_without_condition_fail(testdir):
-    """Expected to fail as condition for open JIRA is False"""
+    """Expected to fail as condition is False"""
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile("""
         import pytest
@@ -208,7 +208,7 @@ def test_multiple_jira_markers_without_condition_fail(testdir):
     result.assert_outcomes(0, 0, 1)
 
 def test_multiple_jira_markers_with_one_condition_pass(testdir):
-    """Expected to fail as condition for open JIRA is False"""
+    """Expected to skip as condition for JIRA tickets is True"""
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile("""
         import pytest

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -137,6 +137,89 @@ def test_open_jira_marker_pass(testdir):
     assert_outcomes(result, 0, 0, 0, 0, 1)
 
 
+def test_open_jira_marker_with_condition_pass(testdir):
+    """Expected skip due to unresolved JIRA"""
+    testdir.makeconftest(CONFTEST)
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.jira("ORG-1382", condition=True)
+        def test_pass():
+            assert False
+    """)
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    assert_outcomes(result, 0, 0, 0, xfailed=1)
+
+
+def test_open_jira_marker_without_condition_fail(testdir):
+    """Expected skip due to unresolved JIRA"""
+    testdir.makeconftest(CONFTEST)
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.jira("ORG-1382", condition=False)
+        def test_fail():
+            assert False
+    """)
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    result.assert_outcomes(0, 0, 1)
+
+
+def test_multiple_jira_markers_with_condition_pass(testdir):
+    """Expected skip due to unresolved JIRA"""
+    testdir.makeconftest(CONFTEST)
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.jira("ORG-1382", condition=True)
+        @pytest.mark.jira("ORG-1412", condition=True)
+        def test_pass():
+            assert False
+    """)
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    assert_outcomes(result, 0, 0, 0, xfailed=1)
+
+
+def test_multiple_jira_markers_open_without_condition_fail(testdir):
+    """Expected to fail as condition for open JIRA is False"""
+    testdir.makeconftest(CONFTEST)
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.jira("ORG-1382", condition=False)
+        @pytest.mark.jira("ORG-1412", condition=True)
+        def test_fail():
+            assert False
+    """)
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    result.assert_outcomes(0, 0, 1)
+
+def test_multiple_jira_markers_without_condition_fail(testdir):
+    """Expected to fail as condition for open JIRA is False"""
+    testdir.makeconftest(CONFTEST)
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.jira("ORG-1382", "ORG-1412", condition=False)
+        def test_fail():
+            assert False
+    """)
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    result.assert_outcomes(0, 0, 1)
+
+def test_multiple_jira_markers_with_one_condition_pass(testdir):
+    """Expected to fail as condition for open JIRA is False"""
+    testdir.makeconftest(CONFTEST)
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.jira("ORG-1382", "ORG-1412", condition=True)
+        def test_pass():
+            assert False
+    """)
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    assert_outcomes(result, 0, 0, 0, xfailed=1)
+
 def test_open_jira_docstr_pass(testdir):
     """Expected skip due to unresolved JIRA Issue %s"""
     testdir.makeconftest(CONFTEST)

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -172,8 +172,8 @@ def test_open_jira_marker_with_callable_skipif_pass(testdir):
     testdir.makepyfile("""
         import pytest
 
-        keys = ('a', 'b')
-        @pytest.mark.jira("ORG-1382", skipif=lambda: 'a' in keys)
+        @pytest.mark.jira("ORG-1382", "ORG-1412",
+            skipif=lambda i: i.get('status') in ('to do', 'done'))
         def test_pass():
             assert False
     """)
@@ -181,15 +181,15 @@ def test_open_jira_marker_with_callable_skipif_pass(testdir):
     assert_outcomes(result, 0, 0, 0, xfailed=1)
 
 
-def test_open_jira_marker_without_callable_skipif_fail(testdir):
+def test_open_jira_marker_with_callable_skipif_fail(testdir):
     """Expected test to fail as unresolved JIRA marker is ignored
     due to False-like return from lambda"""
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile("""
         import pytest
 
-        keys = ('a', 'b')
-        @pytest.mark.jira("ORG-1382", skipif=lambda: 'c' in keys)
+        @pytest.mark.jira("ORG-1382", "ORG-1412",
+            skipif=lambda i: i.get('status') == 'waiting')
         def test_fail():
             assert False
     """)


### PR DESCRIPTION
Add optional keyword argument 'condition' to jira markers to be able to disable marker if conditions are not met for example if Jira issue is specific only for one environment but does not affect others.