### PR TITLE
Add supporting of xfail_strict ini parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,10 @@ Test results
    -  and the *run=False*, the test is **skiped**
 
    -  and the *run=True* or not set, the test is executed and based on it
-      the result is **xpassed** (e.g. unexpected pass) or **xfailed** (e.g. expected fail)
+      the result is **xpassed** (e.g. unexpected pass) or **xfailed** (e.g. expected fail).
+      Interpretation of **xpassed** result depends on the py.test ini-file **xfail_strict** value,
+      i.e. with *xfail_strict=true* **xpassed** results will fail the test suite.
+      More information about strict xfail available on the py.test `doc <https://docs.pytest.org/en/latest/skipping.html#strict-parameter>`__
 
 -  If the test **resolved** ...
 
@@ -190,9 +193,9 @@ Usage
 
    Configuration options can be overridden with command line options as well.
    For all available command line options run following command.
-   
+
    .. code:: sh
-   
+
      py.test --help
 
 2. Mark your tests with jira marker and issue id.

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -901,3 +901,23 @@ def test_run_false_for_resolved_issue(testdir):
     """)
     result = testdir.runpytest(*PLUGIN_ARGS)
     result.assert_outcomes(1, 0, 0)
+
+
+def test_xfail_strict(testdir):
+    testdir.makeconftest(CONFTEST)
+    testdir.makefile(
+        '.ini',
+        pytest="\n".join([
+            '[pytest]',
+            'xfail_strict = True',
+        ])
+    )
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.jira("ORG-1382")
+        def test_pass():
+            assert True
+    """)
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    assert_outcomes(result, passed=0, skipped=0, failed=1, error=0, xfailed=0)


### PR DESCRIPTION
Py.test's with `xfail_strict=true` treat XPASS result as an failed.
This patch adds same behaviour for `jira` marked tests.