### PR TITLE
Align plugin with pytest version 4.0

### DIFF
--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -15,6 +15,7 @@ import sys
 import pytest
 import requests
 import six
+from distutils.version import LooseVersion
 
 DEFAULT_RESOLVE_STATUSES = 'closed', 'resolved'
 DEFAULT_RUN_TEST_CASE = True
@@ -77,6 +78,12 @@ class JiraHooks(object):
         else:
             return not self.is_affected(issue_id)
 
+    def get_marker(self, item):
+        if LooseVersion(pytest.__version__) >= LooseVersion("4.0.0"):
+            return item.get_closest_marker("jira")
+        else:
+            return item.keywords.get("jira")
+
     def pytest_collection_modifyitems(self, config, items):
         for item in items:
             try:
@@ -85,8 +92,10 @@ class JiraHooks(object):
                 pytest.exit(exc)
 
             jira_run = self.run_test_case
-            if 'jira' in item.keywords:
-                jira_run = item.keywords['jira'].kwargs.get('run', jira_run)
+
+            marker = self.get_marker(item)
+            if marker:
+                jira_run = marker.kwargs.get('run', jira_run)
 
             for issue_id, skipif in jira_ids:
                 try:
@@ -237,23 +246,32 @@ class JiraMarkerReporter(object):
         self.docs = docs
         self.strategy = strategy.lower()
 
+    def _get_marks(self, item):
+        marks = []
+        if LooseVersion(pytest.__version__) >= LooseVersion("4.0.0"):
+            for mark in item.iter_markers("jira"):
+                marks.append(mark)
+        else:
+            if 'jira' in item.keywords:
+                marker = item.keywords['jira']
+                # process markers independently
+                if not isinstance(marker, (list, tuple)):
+                    marker = [marker]
+                for mark in marker:
+                    marks.append(mark)
+        return marks
+
     def get_jira_issues(self, item):
         jira_ids = []
-        # Was the jira marker used?
-        if 'jira' in item.keywords:
-            marker = item.keywords['jira']
-            # process markers independently
-            if not isinstance(marker, (list, tuple)):
-                marker = [marker]
-            for mark in marker:
-                skip_if = mark.kwargs.get('skipif', True)
+        for mark in self._get_marks(item):
+            skip_if = mark.kwargs.get('skipif', True)
 
-                if len(mark.args) == 0:
-                    raise TypeError(
-                        'JIRA marker requires one, or more, arguments')
+            if len(mark.args) == 0:
+                raise TypeError(
+                    'JIRA marker requires one, or more, arguments')
 
-                for arg in mark.args:
-                    jira_ids.append((arg, skip_if))
+            for arg in mark.args:
+                jira_ids.append((arg, skip_if))
 
         # Was a jira issue referenced in the docstr?
         if self.docs and item.function.__doc__:

--- a/requirements-pytest3.txt
+++ b/requirements-pytest3.txt
@@ -1,0 +1,3 @@
+pytest>=2.2.4,<4.0.0
+six
+requests>=2.13.0

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from distutils.version import LooseVersion
 
 CONFTEST = """
 import pytest
@@ -902,7 +903,30 @@ def test_xfail_strict(testdir):
     assert_outcomes(result, passed=0, skipped=0, failed=1, error=0, xfailed=0)
 
 
-def test_jira_marker_with_parametrize(testdir):
+@pytest.mark.skipif(
+    LooseVersion(pytest.__version__) < LooseVersion("3.0.0"),
+    reason="requires pytest-3 or higher")
+def test_jira_marker_with_parametrize_pytest3(testdir):
+    """"""
+    testdir.makeconftest(CONFTEST)
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.parametrize('arg', [
+            pytest.param(1, marks=pytest.mark.jira("ORG-1382", run=True)),
+            2,
+        ])
+        def test_fail(arg):
+            assert False
+    """)
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    assert_outcomes(result, 0, 0, failed=1, xfailed=1)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.__version__) >= LooseVersion("3.0.0"),
+    reason="requires pytest-2 or lower")
+def test_jira_marker_with_parametrize_pytest2(testdir):
     """"""
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile("""

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py27,py27-pytest2,py34,py35,py36,pep8
+envlist = py27,py27-pytest2,py27-pytest3,py34,py35,py36,pep8
 [tox:travis]
-2.7 = py27, pep8, py27-pytest2
+2.7 = py27, pep8, py27-pytest2, py27-pytest3
 3.4 = py34, pep8
 3.5 = py35, pep8
 3.6 = py36, pep8
@@ -21,6 +21,15 @@ commands=flake8 setup.py pytest_jira.py tests
 deps=
   -rtests/requirements.txt
   -rrequirements-pytest2.txt
+setenv =
+  PYTEST_ADDOPTS=-p pytester --basetemp={envtmpdir}
+commands=
+  coverage run --source pytest_jira -m py.test
+  coverage report
+[testenv:py27-pytest3]
+deps=
+  -rtests/requirements.txt
+  -rrequirements-pytest3.txt
 setenv =
   PYTEST_ADDOPTS=-p pytester --basetemp={envtmpdir}
 commands=


### PR DESCRIPTION
* Align plugin with pytest version 4.0
    
    Fixes: #96

* tox: add test for pytest3
    
    Since there is new version of pytest4, we still want to be compatible
    with older versions of pytest. from this reason this patch adds test for
    pytest3 to ensure compatibility with this version.
    
Signed-off-by: Lukas Bednar <lbednar@redhat.com>