### PR TITLE
 Look in the tests root dir for jira.cfg and not only in the current dir

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,7 @@ Usage
    * /etc/jira.cfg
    * ~/jira.cfg
    * tests\_root\_dir/jira.cfg
+   * tests\_test\_dir/jira.cfg
 
    The configuration file is loaded in that order mentioned above.
    That means that first options from global configuration are loaded,

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -338,7 +338,7 @@ def pytest_addoption(parser):
     config = six.moves.configparser.ConfigParser()
     config.read([
         str(os.path.join('/', 'etc', 'jira.cfg')),
-        str(os.path.join(parser.extra_info['rootdir'], 'jira.cfg')),
+        str(os.path.join(str(parser.extra_info['rootdir']), 'jira.cfg')),
         str(os.path.expanduser(os.path.join('~', 'jira.cfg'))),
         'jira.cfg',
     ])

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -337,9 +337,9 @@ def pytest_addoption(parser):
     # FIXME - Change to a credentials.yaml ?
     config = six.moves.configparser.ConfigParser()
     config.read([
-        str(os.path.join('/', 'etc', 'jira.cfg')),
-        str(os.path.join(str(parser.extra_info['rootdir']), 'jira.cfg')),
-        str(os.path.expanduser(os.path.join('~', 'jira.cfg'))),
+        os.path.join('/', 'etc', 'jira.cfg'),
+        os.path.join(str(parser.extra_info['rootdir']), 'jira.cfg'),
+        os.path.expanduser(os.path.join('~', 'jira.cfg')),
         'jira.cfg',
     ])
 

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -338,6 +338,7 @@ def pytest_addoption(parser):
     config = six.moves.configparser.ConfigParser()
     config.read([
         '/etc/jira.cfg',
+        os.path.join(parser.extra_info['rootdir'], 'jira.cfg'),
         os.path.expanduser('~/jira.cfg'),
         'jira.cfg',
     ])

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -337,9 +337,9 @@ def pytest_addoption(parser):
     # FIXME - Change to a credentials.yaml ?
     config = six.moves.configparser.ConfigParser()
     config.read([
-        os.path.join('/', 'etc', 'jira.cfg'),
-        os.path.join(parser.extra_info['rootdir'], 'jira.cfg'),
-        os.path.expanduser(os.path.join('~', 'jira.cfg')),
+        str(os.path.join('/', 'etc', 'jira.cfg')),
+        str(os.path.join(parser.extra_info['rootdir'], 'jira.cfg')),
+        str(os.path.expanduser(os.path.join('~', 'jira.cfg'))),
         'jira.cfg',
     ])
 

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -337,9 +337,9 @@ def pytest_addoption(parser):
     # FIXME - Change to a credentials.yaml ?
     config = six.moves.configparser.ConfigParser()
     config.read([
-        '/etc/jira.cfg',
+        os.path.join('/', 'etc', 'jira.cfg'),
         os.path.join(parser.extra_info['rootdir'], 'jira.cfg'),
-        os.path.expanduser('~/jira.cfg'),
+        os.path.expanduser(os.path.join('~', 'jira.cfg')),
         'jira.cfg',
     ])
 


### PR DESCRIPTION
My tests are ordered like this
```
test
│   jira.cfg
│   conftest.py
│   ...
│
└───category1
│   │   conftest.py
│   │   ...
│
│   
└───category2
│   │   conftest.py
│   │   ...
│
```
When starting pytest within _category1_ the higher-level _conftest.py_ is included by pytest, such that _test_ is the actual root dir of the tests. But the _jira.cfg_ in the root dir is ignored. This PR aims to change that!

This PR is quite conservative, I'd rather move the config to the _pytest.ini_, but I'll do another PR for that ;-)