### PR TITLE
pass permissions parameter during connection check to solve connection issue

### DIFF
--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -207,7 +207,9 @@ class JiraSiteConnection(object):
     def check_connection(self):
         # This URL work for both anonymous and logged in users
         auth_url = '{url}/rest/api/2/mypermissions'.format(url=self.url)
-        r = self._jira_request(auth_url)
+        r = self._jira_request(
+            auth_url, params={'permissions': 'BROWSE_PROJECTS'}
+        )
 
         # For some reason in case on invalid credentials the status is still
         # 200 but the body is empty


### PR DESCRIPTION
Jira has announced back in July of last year a new query parameter to the Get my permissions.
Sending Get to mypermissions without a permissions parameter results in 400 error.
A BROWSE_PROJECTS permission was added to the request, this should solve issue #111 