### PR TITLE
Use packaging.version

### DIFF
--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -276,7 +276,7 @@ class JiraMarkerReporter(object):
 
     def _get_marks(self, item):
         marks = []
-        if LooseVersion(pytest.__version__) >= LooseVersion("3.6.0"):
+        if Version(pytest.__version__) >= Version("3.6.0"):
             for mark in item.iter_markers("jira"):
                 marks.append(mark)
         else:

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -11,7 +11,7 @@ Author: James Laska
 import os
 import re
 import sys
-from distutils.version import LooseVersion
+from packaging.version import Version
 from json import JSONDecodeError
 
 import pytest
@@ -91,7 +91,7 @@ class JiraHooks(object):
             return not self.is_affected(issue_id)
 
     def get_marker(self, item):
-        if LooseVersion(pytest.__version__) >= LooseVersion("3.6.0"):
+        if Version(pytest.__version__) >= Version("3.6.0"):
             return item.get_closest_marker("jira")
         else:
             return item.keywords.get("jira")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ six
 requests>=2.13.0
 retry>=0.9.2
 marshmallow>=3.2.0
+packaging

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 flake8
 coverage
+packaging

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,5 +1,5 @@
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pytest
 
@@ -916,7 +916,7 @@ def test_xfail_strict(testdir):
 
 
 @pytest.mark.skipif(
-    LooseVersion(pytest.__version__) < LooseVersion("3.0.0"),
+    Version(pytest.__version__) < Version("3.0.0"),
     reason="requires pytest-3 or higher")
 def test_jira_marker_with_parametrize_pytest3(testdir):
     """"""
@@ -936,7 +936,7 @@ def test_jira_marker_with_parametrize_pytest3(testdir):
 
 
 @pytest.mark.skipif(
-    LooseVersion(pytest.__version__) >= LooseVersion("3.0.0"),
+    Version(pytest.__version__) >= Version("3.0.0"),
     reason="requires pytest-2 or lower")
 def test_jira_marker_with_parametrize_pytest2(testdir):
     """"""


### PR DESCRIPTION
Fix:

DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(pytest.__version__) >= LooseVersion("3.6.0"):
