### PR TITLE
Enable using envvar for username

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,11 +195,13 @@ Usage
      # connection_error_strategy [strict|skip|ignore] Choose how to handle connection errors
      # return_jira_metadata = False (return Jira issue with metadata instead of boolean result)
 
-   You can set the password field by setting the PYTEST_JIRA_PASSWORD environment variable:
+   You can set the password and username fields by setting the PYTEST_JIRA_PASSWORD and PYTEST_JIRA_USERNAME
+   environment variables:
 
     .. code:: sh
 
       export PYTEST_JIRA_PASSWORD="FOO"
+      export PYTEST_JIRA_USERNAME="BAR"
 
    Configuration options can be overridden with command line options as well.
    For all available command line options run following command.

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -30,6 +30,7 @@ SKIP = 'skip'
 IGNORE = 'ignore'
 PLUGIN_NAME = "jira_plugin"
 PASSWORD_ENV_VAR = 'PYTEST_JIRA_PASSWORD'
+USERNAME_ENV_VAR = 'PYTEST_JIRA_USERNAME'
 
 
 class JiraHooks(object):
@@ -513,7 +514,7 @@ def pytest_configure(config):
     if config.getvalue('jira') and config.getvalue('jira_url'):
         jira_connection = JiraSiteConnection(
             config.getvalue('jira_url'),
-            config.getvalue('jira_username'),
+            os.getenv(USERNAME_ENV_VAR) or config.getvalue('jira_username'),
             os.getenv(PASSWORD_ENV_VAR) or config.getvalue('jira_password'),
             config.getvalue('jira_verify'),
             config.getvalue('jira_token'),


### PR DESCRIPTION
Same way as https://github.com/rhevm-qe-automation/pytest_jira/pull/97 enabled to receive password using PYTEST_JIRA_PASSWORD environmental variable
This PR enables to receive username using PYTEST_JIRA_USERNAME environmental variable

Username is also protected information to avoid from static configuration.

Please let me know if anything else is needed.