### PR TITLE
Bump retry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Requires
 -  pytest >= 2.2.3
 -  requests >= 2.13.0
 -  six
--  retry>=0.9.2
+-  retry2>=0.9.5
 -  marshmallow>=3.2.0
 
 Installation
@@ -232,4 +232,3 @@ In order to execute tests run
 .. code:: sh
 
   $ tox
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest>=2.2.4
 six
 requests>=2.13.0
-retry>=0.9.2
+retry2>=0.9.5
 marshmallow>=3.2.0
 packaging


### PR DESCRIPTION
`retry` is no longer maintained and has vulnerabilities (from py, see below). Let's switch to `retry2`. 

Name | Version | ID | Fix Versions | Description
-- | -- | -- | -- | --
py | 1.11.0 | PYSEC-2022-42969 |   | The py library through 1.11.0 for Python allows remote attackers to conduct a ReDoS (Regular expression Denial of Service) attack via a Subversion repository with crafted info data, because the InfoSvnCommand argument is mishandled.
