### PR TITLE
Add class/module/package/session scoped jira_issue fixtures.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ Fixture usage
 -------------
 
 Besides a test marker, you can also use the added ``jira_issue`` fixture. This enables examining issue status mid test
-and not just at the beginning of a test. The fixture return a boolean representing the state of the issue.
+and not just at the beginning of a test. The fixture returns a boolean representing the state of the issue.
 If the issue isn't found, or the jira plugin isn't loaded, it returns ``None``.
 
 The same API is available at other pytest scopes via ``jira_issue_scope_class``,

--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,9 @@ Besides a test marker, you can also use the added ``jira_issue`` fixture. This e
 and not just at the beginning of a test. The fixture return a boolean representing the state of the issue.
 If the issue isn't found, or the jira plugin isn't loaded, it returns ``None``.
 
+The same API is available at other pytest scopes via ``jira_issue_scope_class``,
+``jira_issue_scope_module``, ``jira_issue_scope_package``, and ``jira_issue_scope_session``.
+
 .. code:: python
 
     NICE_ANIMALS = ["bird", "cat", "dog"]

--- a/pytest_jira.py
+++ b/pytest_jira.py
@@ -644,14 +644,8 @@ def pytest_configure(config):
         assert ok
 
 
-@pytest.fixture
-def jira_issue(request):
-    """
-    Returns a bool representing the state of the issue, or None if no
-    connection could be made. See
-    https://github.com/rhevm-qe-automation/pytest_jira#fixture-usage
-    for more details
-    """
+def _jira_issue_checker(request):
+    """Return a callable that reports whether a JIRA issue is still open."""
 
     def wrapper_jira_issue(issue_id):
         jira_plugin = request.config.pluginmanager.getplugin(PLUGIN_NAME)
@@ -669,3 +663,38 @@ def jira_issue(request):
                     raise
 
     return wrapper_jira_issue
+
+
+@pytest.fixture
+def jira_issue(request):
+    """
+    Returns a bool representing the state of the issue, or None if no
+    connection could be made. See
+    https://github.com/rhevm-qe-automation/pytest_jira#fixture-usage
+    for more details
+    """
+    return _jira_issue_checker(request)
+
+
+@pytest.fixture(scope="class")
+def jira_issue_scope_class(request):
+    """Class-scoped variant of :func:`jira_issue`."""
+    return _jira_issue_checker(request)
+
+
+@pytest.fixture(scope="module")
+def jira_issue_scope_module(request):
+    """Module-scoped variant of :func:`jira_issue`."""
+    return _jira_issue_checker(request)
+
+
+@pytest.fixture(scope="package")
+def jira_issue_scope_package(request):
+    """Package-scoped variant of :func:`jira_issue`."""
+    return _jira_issue_checker(request)
+
+
+@pytest.fixture(scope="session")
+def jira_issue_scope_session(request):
+    """Session-scoped variant of :func:`jira_issue`."""
+    return _jira_issue_checker(request)

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1030,6 +1030,31 @@ def test_jira_fixture_run_negative(testdir):
     result.assert_outcomes(0, 0, 1)
 
 
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "jira_issue_scope_class",
+        "jira_issue_scope_module",
+        "jira_issue_scope_package",
+        "jira_issue_scope_session",
+    ],
+)
+def test_jira_fixture_scoped_run_positive(testdir, fixture_name):
+    testdir.makeconftest(CONFTEST)
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def test_pass({fixture_name}):
+            assert {fixture_name}("ORG-1382")
+    """.format(
+            fixture_name=fixture_name
+        )
+    )
+    result = testdir.runpytest(*PLUGIN_ARGS)
+    result.assert_outcomes(1, 0, 0)
+
+
 def test_run_false_for_resolved_issue(testdir):
     testdir.makeconftest(CONFTEST)
     testdir.makepyfile(


### PR DESCRIPTION
Extract shared checker logic so callers can reuse the same API at every pytest scope without duplicating plugin lookup or error handling.

## Summary by Sourcery

Introduce reusable JIRA issue checker helper and add scoped variants of the jira_issue fixture.

New Features:
- Add class-, module-, package-, and session-scoped jira_issue fixtures that share the same JIRA issue checking behavior as the existing function-scoped fixture.

Enhancements:
- Extract shared JIRA issue checker logic into a helper to avoid duplicating plugin lookup and error handling across fixtures.

Tests:
- Add parametrized tests to verify that all new scoped jira_issue fixtures work correctly with passing JIRA issues.